### PR TITLE
Add EqualConcentration instead of confusing FixedVolume

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -72,7 +72,7 @@ jobs:
         python -m pip install --upgrade .[testing]
     - name: Test with tox/pytest
       run: |
-        python -m pytest --cov --cov-report=xml
+        python -m pytest --cov alhambra_mixes --cov-report=xml
 
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v1

--- a/src/alhambra_mixes/actions.py
+++ b/src/alhambra_mixes/actions.py
@@ -153,12 +153,12 @@ class FixedVolume(AbstractAction):
         if (cls is FixedVolume) and ("equal_conc" in kwargs):
             if kwargs["equal_conc"] is not False:
                 c = super().__new__(EqualConcentration)
-                # print(kwargs)
-                # c.__init__(*args, **kwargs, method=equal_conc)
-                # print("Hi")
                 return c
+            else:
+                raise ValueError(
+                    "FixedVolume no longer supports equal_conc=False, but behaves that way by default.  Remove equal_conc=False and try again."
+                )
         c = super().__new__(cls)
-        # c.__init__(*args, **kwargs)
         return c
 
     def with_reference(self, reference: Reference) -> FixedVolume:

--- a/src/alhambra_mixes/locations.py
+++ b/src/alhambra_mixes/locations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+from math import isnan
 from typing import Iterable, Literal, cast, overload
 from math import isnan
 

--- a/src/alhambra_mixes/mixes.py
+++ b/src/alhambra_mixes/mixes.py
@@ -8,10 +8,10 @@ import decimal
 import enum
 import json
 import logging
-import math
 import warnings
 from abc import ABC, abstractmethod
 from decimal import Decimal
+from math import isnan
 from os import PathLike
 from pathlib import Path
 from typing import (
@@ -210,7 +210,7 @@ class Mix(AbstractComponent):
         otherwise, the sum of the transfer volumes of each component.
         """
         if self.fixed_total_volume is not None and not (
-            math.isnan(self.fixed_total_volume.m)
+            isnan(self.fixed_total_volume.m)
         ):
             return self.fixed_total_volume
         else:
@@ -309,7 +309,7 @@ class Mix(AbstractComponent):
         return any(isinstance(action, FixedConcentration) for action in self.actions)
 
     def has_fixed_total_volume(self) -> bool:
-        return not math.isnan(self.fixed_total_volume.m)
+        return not isnan(self.fixed_total_volume.m)
 
     def validate(
         self,
@@ -337,7 +337,7 @@ class Mix(AbstractComponent):
                 )
             )
 
-        nan_vols = [", ".join(n) for n, x in ntx if math.isnan(x.m)]
+        nan_vols = [", ".join(n) for n, x in ntx if isnan(x.m)]
         if nan_vols:
             error_list.append(
                 VolumeError(
@@ -364,7 +364,7 @@ class Mix(AbstractComponent):
 
         for mixline in mixlines:
             if (
-                not math.isnan(mixline.each_tx_vol.m)
+                not isnan(mixline.each_tx_vol.m)
                 and mixline.each_tx_vol != ZERO_VOL
                 and mixline.each_tx_vol < self.min_volume
             ):

--- a/src/alhambra_mixes/units.py
+++ b/src/alhambra_mixes/units.py
@@ -28,6 +28,7 @@ ureg = pint.UnitRegistry(non_int_type=Decimal)
 ureg.default_format = "~P"
 
 uL = ureg.uL
+# µL = ureg.uL
 uM = ureg.uM
 nM = ureg.nM
 

--- a/tests/test_mixes.py
+++ b/tests/test_mixes.py
@@ -313,6 +313,26 @@ def test_non_plates():
     assert len(ml) == 3
 
 
+def test_fixedvolume_equal_conc_deprecation():
+    s1 = Strand("s1", "200 nM", plate="tube")
+
+    s2 = Strand("s2", "200 nM", plate="tube")
+
+    s3 = Strand("s3", "400 nM", plate="tube")
+
+    s4 = Strand("s4", "400 nM", plate="a different tube")
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"The equal_conc parameter for FixedVolume is no longer supported.",
+    ):
+        a = FixedVolume([s1, s2, s3, s4], "1 uL", equal_conc="min_volume")  # type: ignore
+
+    b = EqualConcentration([s1, s2, s3, s4], "1 uL", method="min_volume")
+
+    assert a == b
+
+
 def test_intermediate_mix_sufficient_volume():
     s1 = Strand("s1", "100 uM", plate="plate1", well="A1")
     s2 = Strand("s2", "100 uM", plate="plate1", well="A2")

--- a/tests/test_mixes.py
+++ b/tests/test_mixes.py
@@ -10,6 +10,7 @@ import pytest
 from alhambra_mixes import (
     Q_,
     Component,
+    EqualConcentration,
     FixedConcentration,
     FixedVolume,
     Mix,
@@ -300,7 +301,7 @@ def test_non_plates():
     s4 = Strand("s4", "400 nM", plate="a different tube")
 
     m = Mix(
-        [MultiFixedVolume([s1, s2, s3, s4], "1 uL", equal_conc="min_volume")],
+        [EqualConcentration([s1, s2, s3, s4], "1 uL", method="min_volume")],
         "test",
         min_volume="0 uL",
     )

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ testpath = tests
 setenv =
     py310-{pandas,none,numba}: COVERAGE_FILE = .coverage.{envname}
 commands =
-    pytest --cov alhambra --cov-report=xml {posargs:-vv}
+    pytest --cov alhambra_mixes --cov-report=xml {posargs:-vv}
 deps =
     pytest
     pytest-cov


### PR DESCRIPTION
Every person who has tried to understand it seems to have found the `equal_conc` parameter to FixedVolume confusing.  So this splits the action into two:

- `FixedVolume` does exactly what it says.  It transfers a fixed volume of each component.  It doesn't care about concentrations, or anything else.
- `EqualConcentration` transfers an equal (but not fixed/set) concentration of each component.  `equal_conc` is now `method`.  The class can just check that transfer concentrations will be equal ("check"), can have a set minimum volume ("min_volume"), can have a set maximum volume ("max_volume"), etc.

~~This is a breaking change that will break quite a bit of current code.~~

This is no longer a major breaking change, as there is code to allow the old behavaviour, mostly with a DeprecationWarning.  However, note that now by default FixedVolume does not check that concentrations are equal, so this may break some code.