### PR TITLE
ToConcentration implementation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -99,8 +99,10 @@ There are two main actions.  `FixedConcentration` is useful when you'd like to a
 
 .. autosummary::
 
-  FixedConcentration
   FixedVolume
+  FixedConcentration
+  EqualConcentration
+  ToConcentration
 
 .. note::
    Previous versions of alhambra_mixes only supported single components for `FixedVolume` and `FixedConcentration`, and included separate `MultiFixedVolume` and `MultiFixedConcentration`  classes for multiple components.  The two `Multi` class names are currently kept for compatibility reasons, as aliases of `FixedVolume` and `FixedConcentration`.

--- a/src/alhambra_mixes/abbreviated.py
+++ b/src/alhambra_mixes/abbreviated.py
@@ -10,6 +10,8 @@ __all__ = (
     "Q_",
     "FV",
     "FC",
+    "EC",
+    "TC",
     "S",
     "C",
     "Ref",
@@ -24,10 +26,13 @@ __all__ = (
     "mL",
     "save_mixes",
     "load_mixes",
+    "ureg",
 )
 
 FV = FixedVolume
 FC = FixedConcentration
+EC = EqualConcentration
+TC = ToConcentration
 S = Strand
 C = Component
 Ref = Reference

--- a/src/alhambra_mixes/actions.py
+++ b/src/alhambra_mixes/actions.py
@@ -496,7 +496,7 @@ class EqualConcentration(FixedVolume):
             sc = self.source_concentrations
             scmin = min(sc)
             return [self.fixed_volume * x for x in _ratio(scmin, sc)]
-        elif self.method is "check":
+        elif self.method == "check":
             sc = self.source_concentrations
             if any(x != sc[0] for x in sc):
                 raise ValueError("Concentrations")
@@ -662,10 +662,10 @@ class FixedConcentration(ActionWithComponents):
 
 @attrs.define()
 class ToConcentration(ActionWithComponents):
-    """An action adding an amount of components such that the concentration of each component in the mix
-    will be at some tapiprget concentration.  Unlike FixedConcentration, which *adds* a certain concentration,
-    this takes into account other contents of the mix, and only adds enough to reach a particular final
-    concentration."""
+    """Add an amount of (non-mix) components to result in a fixed total concentration of each in the mix.
+
+    An action adding an amount of components such that the concentration of each component in the mix
+    will be at some tapiprget concentration.  Unlike FixedConcentration, which *adds* a certain concentration, this takes into account other contents of the mix, and only adds enough to reach a particular final concentration."""
 
     fixed_concentration: Quantity[Decimal] = attrs.field(
         converter=_parse_conc_required, on_setattr=attrs.setters.convert

--- a/src/alhambra_mixes/components.py
+++ b/src/alhambra_mixes/components.py
@@ -39,6 +39,10 @@ class AbstractComponent(ABC):
         return ""
 
     @property
+    def is_mix(self) -> bool:
+        return False
+
+    @property
     def well(self) -> WellPos | None:
         return None
 

--- a/src/alhambra_mixes/mixes.py
+++ b/src/alhambra_mixes/mixes.py
@@ -302,7 +302,7 @@ class Mix(AbstractComponent):
         )
 
     def mixlines(
-        self, tablefmt: str | TableFormat, buffer_name: str = "Buffer"
+        self, tablefmt: str | TableFormat = "pipe", buffer_name: str = "Buffer"
     ) -> Sequence[MixLine]:
         mixlines: list[MixLine] = []
 

--- a/src/alhambra_mixes/mixes.py
+++ b/src/alhambra_mixes/mixes.py
@@ -159,6 +159,10 @@ class Mix(AbstractComponent):
         on_setattr=attrs.setters.convert,
     )
 
+    @property
+    def is_mix(self) -> bool:
+        return True
+
     def __attrs_post_init__(self) -> None:
         if self.reference is not None:
             self.actions = [
@@ -199,7 +203,9 @@ class Mix(AbstractComponent):
                 Decimal(ac.loc[self.fixed_concentration, "concentration_nM"]), ureg.nM
             )
         elif self.fixed_concentration is None:
-            return self.actions[0].dest_concentrations(self.total_volume)[0]
+            return self.actions[0].dest_concentrations(self.total_volume, self.actions)[
+                0
+            ]
         else:
             raise NotImplemented
 
@@ -216,7 +222,9 @@ class Mix(AbstractComponent):
         else:
             return sum(
                 [
-                    c.tx_volume(self.fixed_total_volume or Q_(DNAN, ureg.uL))
+                    c.tx_volume(
+                        self.fixed_total_volume or Q_(DNAN, ureg.uL), self.actions
+                    )
                     for c in self.actions
                 ],
                 Q_(Decimal(0.0), ureg.uL),
@@ -227,7 +235,7 @@ class Mix(AbstractComponent):
         """
         The volume of buffer to be added to the mix, in addition to the components.
         """
-        mvol = sum(c.tx_volume(self.total_volume) for c in self.actions)
+        mvol = sum(c.tx_volume(self.total_volume, self.actions) for c in self.actions)
         return self.total_volume - mvol
 
     def table(
@@ -299,7 +307,9 @@ class Mix(AbstractComponent):
         mixlines: list[MixLine] = []
 
         for action in self.actions:
-            mixlines += action._mixlines(tablefmt=tablefmt, mix_vol=self.total_volume)
+            mixlines += action._mixlines(
+                tablefmt=tablefmt, mix_vol=self.total_volume, actions=self.actions
+            )
 
         if self.has_fixed_total_volume():
             mixlines.append(MixLine([buffer_name], None, None, self.buffer_volume))
@@ -411,7 +421,7 @@ class Mix(AbstractComponent):
         # XXX: this assumes 1-1 correspondence between mixlines and actions (true in current implementation)
         for action in self.actions:
             for component, volume in zip(
-                action.components, action.each_volumes(self.total_volume)
+                action.components, action.each_volumes(self.total_volume, self.actions)
             ):
                 if isinstance(component, Mix):
                     if component.fixed_total_volume < volume:
@@ -433,7 +443,7 @@ class Mix(AbstractComponent):
         cps = _empty_components()
 
         for action in self.actions:
-            mcomp = action.all_components(self.total_volume)
+            mcomp = action.all_components(self.total_volume, self.actions)
             cps, _ = cps.align(mcomp)
             cps.loc[:, "concentration_nM"].fillna(Decimal("0.0"), inplace=True)
             cps.loc[mcomp.index, "concentration_nM"] += mcomp.concentration_nM

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,46 @@
+import pytest
+
+from alhambra_mixes.abbreviated import *
+
+
+def test_names_and_numbers():
+    a = TC(["a", "b", "c"], fixed_concentration="100 µM")
+    b = EC(["a", "b", "c"], fixed_volume="100 µL")
+    c = FV(["a", "b", "c"], fixed_volume="100 µL")
+    d = FC(["a", "b", "c"], fixed_concentration="100 µM")
+
+    assert a.name == b.name == c.name == d.name == "a, b, c"
+
+    cf = FV(["a", "b"], fixed_volume="100 µL", set_name="set name")
+    df = FC("a long name", fixed_concentration="100 µM", set_name="set name")
+    assert cf.name == "set name" == df.name
+    assert cf.number == 2
+    assert 1 == df.number
+
+
+def test_ec_volumes():
+    a = C("A", "50 nM")
+    b = C("B", "100 nM")
+    c = C("C", "50 nM")
+
+    assert EC([a, b], Q_("10", uL), method="min_volume").each_volumes(
+        ureg("100 uL")
+    ) == [ureg("20 µL"), ureg("10 µL")]
+
+    assert EC([a, b], Q_("10", uL), method="max_volume").each_volumes(
+        ureg("100 uL")
+    ) == [ureg("10 µL"), ureg("5 µL")]
+
+    assert EC([a, b], Q_("10", uL), method=("max_fill", "Buffer")).each_volumes(
+        ureg("100 uL")
+    ) == [
+        ureg("10 µL"),
+        ureg("5 µL"),
+    ]  # FIXME
+
+    with pytest.raises(ValueError):
+        EC([a, b], Q_("10", uL), method="check").each_volumes(ureg("100 uL"))
+
+    assert EC([a, c], Q_("10", uL), method="max_volume").each_volumes(
+        ureg("100 uL")
+    ) == [ureg("10 µL"), ureg("10 µL")]

--- a/tests/test_mixes.py
+++ b/tests/test_mixes.py
@@ -25,6 +25,7 @@ from alhambra_mixes import (
     uM,
     ureg,
 )
+from alhambra_mixes.actions import ToConcentration
 
 
 def test_wellpos_movement():
@@ -365,6 +366,48 @@ def test_intermediate_mix_sufficient_volume():
 
     with pytest.raises(VolumeError):
         final_mix.table(raise_failed_validation=True)
+
+
+def test_toconcentration():
+
+    ca = Component("A", "1 µM")
+    cb = Component("B", "1 µM")
+    cc = Component("C", "1 µM")
+
+    ma = Mix(
+        [FixedConcentration(ca, "100 nM"), FixedVolume(cb, "11 µL")],
+        "imix",
+        fixed_total_volume="100 µL",
+    )
+
+    tca = ToConcentration(ca, "150 nM")
+    tcb = ToConcentration([ca, cb], "150 nM")
+
+    assert tcb.dest_concentrations(
+        ureg("100 µL"),
+        [FixedConcentration([ca], "50 nM"), FixedConcentration([cc], "55 nM")],
+    ) == [ureg("100 nM"), ureg("150 nM")]
+
+    assert tcb.dest_concentrations(
+        ureg("100 µL"), [FixedVolume([ma], "50 µL"), FixedConcentration(ca, "10 nM")]
+    ) == [ureg("90 nM"), ureg("95 nM")]
+
+    mix = Mix(
+        [
+            ToConcentration(ca, "150 nM"),
+            ToConcentration([cb, cc], "140 nM"),
+            FixedConcentration(ma, "50 nM"),
+            FixedVolume(cc, "1 µL"),
+        ],
+        "testmix",
+        fixed_total_volume="100 µL",
+    )
+
+    ac = mix.all_components()
+
+    assert ac.loc["A", "concentration_nM"] == 150
+    assert ac.loc["B", "concentration_nM"] == 140
+    assert ac.loc["C", "concentration_nM"] == 140
 
 
 def test_combine_plate_actions():

--- a/tests/test_mixes.py
+++ b/tests/test_mixes.py
@@ -409,6 +409,14 @@ def test_toconcentration():
     assert ac.loc["B", "concentration_nM"] == 140
     assert ac.loc["C", "concentration_nM"] == 140
 
+    ml = mix.mixlines("pipe")
+
+    print(mix.table())
+
+    assert [m.dest_conc for m in ml] == [
+        Q_(x, nM) for x in ["100", "85", "130", "50", "10"]
+    ] + [None]
+
 
 def test_combine_plate_actions():
     from alhambra_mixes import Mix, MultiFixedConcentration, Strand


### PR DESCRIPTION
This implements a ToConcentration action, which makes the concentration of (non-mix) components in a mix equal to some value.  It is distinct from FixedConcentration in that the latter adds a certain concentration, regardless of what might be in the mix from elsewhere. 

This action is useful if, eg, you have some mixes with MgCl₂ or polysorbate 20 added, and other without them, and you want to have a mix with those at specific concentrations, taking into account what has been added from the various components.