### PR TITLE
fixes bug in `Reference.plate_maps`

### DIFF
--- a/src/alhambra_mixes/references.py
+++ b/src/alhambra_mixes/references.py
@@ -63,9 +63,7 @@ class Reference:
         return len(self.df)
 
     def plate_map(
-        self,
-        name: str,
-        plate_type: PlateType = PlateType.wells96,
+        self, name: str, plate_type: PlateType = PlateType.wells96
     ) -> PlateMap:
         """
         :param name:
@@ -79,7 +77,7 @@ class Reference:
         """
         well_to_strand_name = {}
         from .mixes import Strand, PlateMap
-        
+
         for row in self.df.itertuples():
             if row.Plate == name:  # type: ignore
                 well = row.Well  # type: ignore
@@ -218,10 +216,7 @@ class Reference:
                         str(WellPos(x)) for x in sheet.loc[:, "well position"]
                     ]
                     sheet.rename(
-                        {
-                            "plate name": "Plate",
-                            "sequence name": "Name",
-                        },
+                        {"plate name": "Plate", "sequence name": "Name"},
                         axis="columns",
                         inplace=True,
                     )

--- a/src/alhambra_mixes/references.py
+++ b/src/alhambra_mixes/references.py
@@ -78,6 +78,7 @@ class Reference:
             `name`. Currently always makes a 96-well plate.
         """
         well_to_strand_name = {}
+        from .mixes import Strand, PlateMap
         for row in self.df.itertuples():
             if row.Plate == name:  # type: ignore
                 well = row.Well  # type: ignore

--- a/src/alhambra_mixes/references.py
+++ b/src/alhambra_mixes/references.py
@@ -79,6 +79,7 @@ class Reference:
         """
         well_to_strand_name = {}
         from .mixes import Strand, PlateMap
+        
         for row in self.df.itertuples():
             if row.Plate == name:  # type: ignore
                 well = row.Well  # type: ignore


### PR DESCRIPTION
This fixes a bug in `Reference.plate_map` where the `Strand` and `PlateMap` objects were not properly imported.

To avoid a circular import error at the submodule level, I had to put the imports inside the `plate_maps` method.