### PR TITLE
Experiment class implementing volume checks and tracking.

### DIFF
--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -14,6 +14,7 @@ Alhambra-mixes organizes the mixing process into several concepts:
 - An *Action* describes how a component or set of components is to be added to a mix.  It may specify that each component be added to get a target concentration in the mix, for example, or that a fixed volume of each component be added.  For example, the `FixedConcentration` action adds a component (or several components) to a mix at a fixed desired concentration, while `FixedVolume` adds components at fixed volumes.
 - A *Mix* is a collection of Actions, each covering some Components.  It may have a fixed volume, or that may be determined by the components.  It may also have a fixed effective concentration (for use as a component), or that may be determined by a particular component.
 - A *Reference* is an object that has information about component concentrations, sequences, and locations.
+- An *Experiment* collects many mixes/components.  These are not necessary, but allow saving and loading to and from files, tracking of produced and used concentrations, and referencing of other components and mixes by name.
 
 Physical units are used extensively in alhambra-mixes.  Internally, the library uses pint to handle units, and the decimal library to handle numbers, to avoid floating point inaccuracies.  While using the library, units can be specifid flexibly as strings, which will be processed as the correct quantity, for example `"50 nM"`, or `"10 µL"`,
 or `"5 uM"`.  If you need to do calculations, quantities can be created using :any:`Q_`, for example, `Q_(10, "µL")`,
@@ -144,3 +145,22 @@ With this reference, components, actions, and mixes can be updated with the info
    Mix.with_reference
    AbstractAction.with_reference
    Component.with_reference
+
+Experiments
+-----------
+
+Experiments hold mixes, and potentially concentrations, to be referred to later and tracked as a group.
+
+Mixes can be added to an experiment using the :any:`Experiment.add_mix` method, or by using `experiment[mix_name] = Mix(...)`.  In the latter case, the name in the Mix does not need to be set: it will be set to `mix_name` when it is added to the experiment.  When mixes are added, components that are string references are resolved to components with the same names in the experiment.  This is obviously not possible if the mix being referred to is only added later: in this case, you can use the :any:`Experiment.resolve_components` method to resolve the references.
+
+A useful feature of an Experiment is that the consumed and produced volumes of mixes, and the consumed volumes of other components, can be tracked across all of the mixes involved:
+
+.. autosummary::
+   Experiment.check_volumes
+   Experiment.consumed_and_produced_volumes
+
+Experiments also allow groups of mixes to be saved and loaded to JSON files.  When written, any mixes used in other mixes are replaced with references to those mixes, so that when the file is loaded, the mixes are linked back together, and changes to one mix in the experiment will propagate to all the mixes that use it:
+
+.. autosummary::
+   Experiment.save
+   Experiment.load

--- a/src/alhambra_mixes/__init__.py
+++ b/src/alhambra_mixes/__init__.py
@@ -5,6 +5,7 @@ from .printing import *
 from .quantitate import *
 from .references import *
 from .units import *
+from .experiments import Experiment
 
 __all__ = (
     "uL",
@@ -14,6 +15,7 @@ __all__ = (
     "ureg",
     "Component",
     "Strand",
+    "Experiment",
     "FixedVolume",
     "FixedConcentration",
     "EqualConcentration",

--- a/src/alhambra_mixes/__init__.py
+++ b/src/alhambra_mixes/__init__.py
@@ -1,11 +1,11 @@
 from .actions import *
 from .components import *
+from .experiments import Experiment
 from .mixes import *
 from .printing import *
 from .quantitate import *
 from .references import *
 from .units import *
-from .experiments import Experiment
 
 __all__ = (
     "uL",

--- a/src/alhambra_mixes/__init__.py
+++ b/src/alhambra_mixes/__init__.py
@@ -35,6 +35,4 @@ __all__ = (
     #    "D",
     "measure_conc_and_dilute",
     "hydrate_and_measure_conc_and_dilute",
-    "save_mixes",
-    "load_mixes",
 )

--- a/src/alhambra_mixes/abbreviated.py
+++ b/src/alhambra_mixes/abbreviated.py
@@ -5,6 +5,7 @@ from .components import *
 from .mixes import *
 from .references import *
 from .units import *
+from .experiments import Experiment
 
 __all__ = (
     "Q_",
@@ -16,6 +17,7 @@ __all__ = (
     "C",
     "Ref",
     "Mix",
+    "Exp",
     #    "µM",
     "uM",
     "nM",
@@ -24,8 +26,6 @@ __all__ = (
     #   "µL",
     "uL",
     "mL",
-    "save_mixes",
-    "load_mixes",
     "ureg",
 )
 
@@ -37,6 +37,7 @@ S = Strand
 C = Component
 Ref = Reference
 Mix = Mix
+Exp = Experiment
 
 µM = ureg("µM")
 uM = ureg("uM")

--- a/src/alhambra_mixes/actions.py
+++ b/src/alhambra_mixes/actions.py
@@ -15,7 +15,7 @@ from .locations import WellPos, mixgaps
 from .printing import MixLine, TableFormat
 from .units import _parse_vol_optional_none_zero
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .references import Reference
     from .experiments import Experiment
     from attrs import Attribute

--- a/src/alhambra_mixes/actions.py
+++ b/src/alhambra_mixes/actions.py
@@ -2,19 +2,22 @@ from __future__ import annotations
 
 import math
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Literal, Sequence, TypeVar
+from math import isnan
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Sequence, TypeVar, cast
+from warnings import warn
 
 import attrs
 import pandas as pd
 
-from warnings import warn
-
 from .components import AbstractComponent, _empty_components, _maybesequence_comps
+from .dictstructure import _STRUCTURE_CLASSES, _structure, _unstructure
 from .locations import WellPos, mixgaps
 from .printing import MixLine, TableFormat
 
 if TYPE_CHECKING:
     from .references import Reference
+    from .experiments import Experiment
+
 from .units import *
 from .units import (
     VolumeError,
@@ -75,6 +78,13 @@ class AbstractAction(ABC):
         ...
 
     @abstractmethod
+    def with_experiment(
+        self: T, experiment: "Experiment", inplace: bool = True
+    ) -> T:  # pragma: no cover
+        """Returns a copy of the action updated from a experiment dataframe."""
+        ...
+
+    @abstractmethod
     def with_reference(self: T, reference: Reference) -> T:  # pragma: no cover
         """Returns a copy of the action updated from a reference dataframe."""
         ...
@@ -111,6 +121,18 @@ class AbstractAction(ABC):
     ) -> list[Quantity[Decimal]]:
         ...
 
+    @classmethod
+    @abstractmethod
+    def _structure(
+        cls, d: dict[str, Any], experiment: "Experiment"
+    ) -> "AbstractAction":  # pragma: no cover
+        ...
+
+    def _unstructure(
+        self, experiment: "Experiment" | None
+    ) -> dict[str, Any]:  # pragma: no cover
+        ...
+
 
 T_AWC = TypeVar("T_AWC", bound="ActionWithComponents")
 
@@ -129,6 +151,22 @@ class ActionWithComponents(AbstractAction):
     def name(self) -> str:
         return ", ".join(c.name for c in self.components)
 
+    def with_experiment(
+        self: T_AWC, experiment: "Experiment", inplace: bool = True
+    ) -> T_AWC:
+        if inplace:
+            self.components = [
+                c.with_experiment(experiment, inplace) for c in self.components
+            ]
+            return self
+        else:
+            return attrs.evolve(
+                self,
+                components=[
+                    c.with_experiment(experiment, inplace) for c in self.components
+                ],
+            )
+
     def with_reference(self: T_AWC, reference: Reference) -> T_AWC:
         return attrs.evolve(
             self, components=[c.with_reference(reference) for c in self.components]
@@ -138,6 +176,43 @@ class ActionWithComponents(AbstractAction):
     def source_concentrations(self) -> list[Quantity[Decimal]]:
         concs = [c.concentration for c in self.components]
         return concs
+
+    def _unstructure(self, experiment: "Experiment" | None) -> dict[str, Any]:
+        d: dict[str, Any] = {}
+        d["class"] = self.__class__.__name__
+        d["components"] = [c._unstructure(experiment) for c in self.components]
+        for a in self.__attrs_attrs__:
+            if a.name == "components":
+                continue
+            val = getattr(self, a.name)
+            if val is a.default:
+                continue
+            # FIXME: nan quantities are always default, and pint handles them poorly
+            if isinstance(val, Quantity) and isnan(val.m):
+                continue
+            d[a.name] = _unstructure(val)
+        return d
+
+    @classmethod
+    def _structure(
+        cls, d: dict[str, Any], experiment: "Experiment" | None = None
+    ) -> "ActionWithComponents":
+        scomps: List[AbstractComponent] = []
+        for cd in d["components"]:
+            if experiment and (cd["name"] in experiment.components):
+                scomps.append(experiment.components[cd["name"]])
+            elif experiment:
+                c = cast(AbstractComponent, _structure(cd, experiment))
+                experiment[c.name] = c
+                scomps.append(c)
+            else:
+                scomps.append(_structure(cd))
+        d["components"] = scomps
+        for k in d.keys():
+            if k == "components":
+                continue
+            d[k] = _structure(d[k])
+        return cls(**d)
 
     def all_components(
         self, mix_vol: Quantity[Decimal], actions: Sequence[AbstractAction] = tuple()
@@ -792,3 +867,6 @@ class ToConcentration(ActionWithComponents):
 
 MultiFixedConcentration = FixedConcentration
 MultiFixedVolume = FixedVolume
+
+for c in [FixedConcentration, FixedVolume, EqualConcentration, ToConcentration]:
+    _STRUCTURE_CLASSES[c.__name__] = c

--- a/src/alhambra_mixes/components.py
+++ b/src/alhambra_mixes/components.py
@@ -15,7 +15,7 @@ from .units import ZERO_VOL, Decimal, Quantity, _parse_conc_optional, nM, ureg
 from .util import _none_as_empty_string
 from .dictstructure import _structure, _unstructure, _STRUCTURE_CLASSES
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .references import Reference
     from .experiments import Experiment
     from attrs import Attribute

--- a/src/alhambra_mixes/components.py
+++ b/src/alhambra_mixes/components.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from math import isnan
-from typing import TYPE_CHECKING, Any, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Sequence, Tuple, TypeVar
 
 import attrs
 import pandas as pd
@@ -10,11 +10,12 @@ import pandas as pd
 from .locations import WellPos, _parse_wellpos_optional
 from .logging import log
 from .printing import TableFormat
-from .units import Decimal, Quantity, _parse_conc_optional, nM, ureg
+from .units import ZERO_VOL, Decimal, Quantity, _parse_conc_optional, nM, ureg
 from .util import _none_as_empty_string
 
 if TYPE_CHECKING:
     from .references import Reference
+
 
 T = TypeVar("T")
 
@@ -71,6 +72,22 @@ class AbstractComponent(ABC):
 
     def printed_name(self, tablefmt: str | TableFormat) -> str:
         return self.name
+
+    def _update_volumes(
+        self,
+        consumed_volumes: Dict[str, Quantity] = {},
+        made_volumes: Dict[str, Quantity] = {},
+    ) -> Tuple[Dict[str, Quantity], Dict[str, Quantity]]:
+        """
+        Given a
+        """
+        if self.name in made_volumes:
+            # We've already been seen.  Ignore our components.
+            return consumed_volumes, made_volumes
+
+        made_volumes[self.name] = ZERO_VOL
+
+        return consumed_volumes, made_volumes
 
 
 @attrs.define()

--- a/src/alhambra_mixes/components.py
+++ b/src/alhambra_mixes/components.py
@@ -3,23 +3,22 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from math import isnan
 from typing import TYPE_CHECKING, Any, Dict, Sequence, Tuple, TypeVar, cast
+from typing_extensions import Self
 
 import attrs
 import pandas as pd
-from typing_extensions import Self
 
-from .dictstructure import _STRUCTURE_CLASSES, _structure, _unstructure
 from .locations import WellPos, _parse_wellpos_optional
 from .logging import log
 from .printing import TableFormat
 from .units import ZERO_VOL, Decimal, Quantity, _parse_conc_optional, nM, ureg
 from .util import _none_as_empty_string
+from .dictstructure import _structure, _unstructure, _STRUCTURE_CLASSES
 
 if TYPE_CHECKING:
-    from attrs import Attribute
-
-    from .experiments import Experiment
     from .references import Reference
+    from .experiments import Experiment
+    from attrs import Attribute
 
 
 T = TypeVar("T")
@@ -177,7 +176,6 @@ class Component(AbstractComponent):
             val = getattr(self, att.name)
             if val is att.default:
                 continue
-            # FIXME: nan quantities are always default, and pint handles them poorly
             if isinstance(val, Quantity) and isnan(val.m):
                 continue
             d[att.name] = _unstructure(val)

--- a/src/alhambra_mixes/dictstructure.py
+++ b/src/alhambra_mixes/dictstructure.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 from .locations import WellPos
 from .units import Quantity
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from attrs import Attribute
 
     from .experiments import Experiment

--- a/src/alhambra_mixes/dictstructure.py
+++ b/src/alhambra_mixes/dictstructure.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .locations import WellPos
+from .units import Quantity
+
+if TYPE_CHECKING:
+    from attrs import Attribute
+
+    from .experiments import Experiment
+
+__all__ = (
+    "_STRUCTURE_CLASSES",
+    "_structure",
+    "_unstructure",
+)
+
+_STRUCTURE_CLASSES: dict[str, Any] = {}
+
+
+def _structure(x: dict[str, Any], experiment: "Experiment" | None = None) -> Any:
+    if isinstance(x, dict) and ("class" in x):
+        c = _STRUCTURE_CLASSES[x["class"]]
+        del x["class"]
+        if hasattr(c, "_structure"):
+            return c._structure(x, experiment)
+        for k in x.keys():
+            x[k] = _structure(x[k])
+        return c(**x)
+    elif isinstance(x, list):
+        return [_structure(y) for y in x]
+    else:
+        return x
+
+
+def _unstructure(x: Any) -> Any:
+    if isinstance(x, Quantity):
+        return str(x)
+    elif isinstance(x, list):
+        return [_unstructure(y) for y in x]
+    elif isinstance(x, WellPos):
+        return str(x)
+    elif hasattr(x, "_unstructure"):
+        return x._unstructure()
+    elif hasattr(x, "__attrs_attrs__"):
+        d = {}
+        d["class"] = x.__class__.__name__
+        for att in x.__attrs_attrs__:  # type: Attribute
+            if att.name in ["reference"]:
+                continue
+            val = getattr(x, att.name)
+            if val is att.default:
+                continue
+            d[att.name] = _unstructure(val)
+        return d
+    else:
+        return x

--- a/src/alhambra_mixes/experiments.py
+++ b/src/alhambra_mixes/experiments.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Dict, Mapping, Sequence, Set, Tuple
+from .mixes import Mix
+from .components import Component
+from .units import Quantity, ZERO_VOL
+import attrs
+
+
+class Experiment:
+    mixes: Sequence[Mix | Component]
+
+    def consumed_volumes(self) -> Mapping[str, Tuple[Quantity, Quantity]]:
+        consumed_volume: Dict[str, Quantity] = {}
+        made_volume: Dict[str, Quantity] = {}
+        for mix in self.mixes:
+            if not isinstance(mix, Mix):
+                continue
+            mix._update_volumes(consumed_volume, made_volume)
+        return {
+            k: (consumed_volume[k], made_volume[k]) for k in consumed_volume
+        }  # FIXME
+
+    def check_volumes(self, showall: bool = False) -> None:
+        """
+        Check to ensure that consumed volumes are less than made volumes.
+        """
+        volumes = self.consumed_volumes()
+        conslines = []
+        badlines = []
+        for k, (consumed, made) in volumes.items():
+            if made.m == 0:
+                conslines.append(f"Consuming {consumed} of untracked {k}.")
+            elif consumed >= made:
+                badlines.append(f"Making {made} of {k} but need at least {consumed}.")
+            elif showall:
+                conslines.append(f"Consuming {consumed} of {k}, making {made}.")
+        print("\n".join(badlines))
+        print("\n")
+        print("\n".join(conslines))

--- a/src/alhambra_mixes/experiments.py
+++ b/src/alhambra_mixes/experiments.py
@@ -76,8 +76,8 @@ class Experiment:
             )
         if mix.name in self.components:
             raise ValueError(f"Mix {mix.name} already exists in experiment.")
-        mix.with_experiment(self, True)
-        self.components[mix.name] = cast(AbstractComponent, mix)
+        mix = mix.with_experiment(self, True)
+        self.components[mix.name] = mix
 
     def __setitem__(self, name: str, value: AbstractComponent) -> None:
         if not value.name:
@@ -88,6 +88,7 @@ class Experiment:
         else:
             if value.name != name:
                 raise ValueError(f"Component name {value.name} does not match {name}.")
+        value = value.with_experiment(self, True)
         self.components[name] = value
 
     def __getitem__(self, name: str) -> AbstractComponent:

--- a/src/alhambra_mixes/experiments.py
+++ b/src/alhambra_mixes/experiments.py
@@ -167,6 +167,16 @@ class Experiment:
             s.close()
         return exp
 
+    def resolve_components(self) -> None:
+        """
+        Resolve string/blank-component components in mixes, searching through the mixes
+        in the experiment.  FIXME Add used mixes to the experiment if they are not already there.
+        """
+        for mix in self:
+            if not isinstance(mix, Mix):
+                continue
+            mix.with_experiment(self, True)
+
     def save(self, filename_or_stream: str | PathLike | TextIO) -> None:
         """
         Save an experiment to a JSON-formatted file.

--- a/src/alhambra_mixes/locations.py
+++ b/src/alhambra_mixes/locations.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import enum
 from math import isnan
 from typing import Iterable, Literal, cast, overload
-from math import isnan
 
 import attrs
 

--- a/src/alhambra_mixes/mixes.py
+++ b/src/alhambra_mixes/mixes.py
@@ -132,6 +132,14 @@ def findloc_tuples(
     return (loc["Name"], loc["Plate"], well)
 
 
+def _maybesequence_action(
+    object_or_sequence: Sequence[AbstractAction] | AbstractAction,
+) -> list[AbstractAction]:
+    if isinstance(object_or_sequence, Sequence):
+        return list(object_or_sequence)
+    return [object_or_sequence]
+
+
 @attrs.define()
 class Mix(AbstractComponent):
     """Class denoting a Mix, a collection of source components mixed to
@@ -139,7 +147,7 @@ class Mix(AbstractComponent):
     """
 
     actions: Sequence[AbstractAction] = attrs.field(
-        converter=_maybesequence, on_setattr=attrs.setters.convert
+        converter=_maybesequence_action, on_setattr=attrs.setters.convert
     )
     name: str
     test_tube_name: str | None = attrs.field(kw_only=True, default=None)
@@ -157,7 +165,7 @@ class Mix(AbstractComponent):
     reference: Reference | None = None
     min_volume: Quantity[Decimal] = attrs.field(
         converter=_parse_vol_optional,
-        default=Q_(Decimal(0.5), uL),
+        default=Q_(Decimal("0.5"), uL),
         kw_only=True,
         on_setattr=attrs.setters.convert,
     )

--- a/src/alhambra_mixes/mixes.py
+++ b/src/alhambra_mixes/mixes.py
@@ -142,7 +142,7 @@ def _maybesequence_action(
     return [object_or_sequence]
 
 
-@attrs.define()
+@attrs.define(eq=False)
 class Mix(AbstractComponent):
     """Class denoting a Mix, a collection of source components mixed to
     some volume or concentration.
@@ -174,6 +174,20 @@ class Mix(AbstractComponent):
 
     @property
     def is_mix(self) -> bool:
+        return True
+
+    def __eq__(self, other: Any) -> bool:
+        if type(self) != type(other):
+            return False
+        for a in self.__attrs_attrs__:  # type: ignore
+            a = cast("Attribute", a)
+            v1 = getattr(self, a.name)
+            v2 = getattr(other, a.name)
+            if isinstance(v1, Quantity):
+                if isnan(v1.m) and isnan(v2.m) and (v1.units == v2.units):
+                    continue
+            if v1 != v2:
+                return False
         return True
 
     def __attrs_post_init__(self) -> None:

--- a/src/alhambra_mixes/mixes.py
+++ b/src/alhambra_mixes/mixes.py
@@ -81,8 +81,6 @@ warnings.filterwarnings(
 __all__ = (
     "Mix",
     "_format_title",
-    "save_mixes",
-    "load_mixes",
 )
 
 MIXHEAD_EA = (

--- a/src/alhambra_mixes/mixes.py
+++ b/src/alhambra_mixes/mixes.py
@@ -57,14 +57,13 @@ from .printing import (
     html_with_borders_tablefmt,
 )
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .references import Reference
     from .experiments import Experiment
     from attrs import Attribute
 
 from .units import *
 from .units import VolumeError, _parse_vol_optional
-from .util import _maybesequence
 
 warnings.filterwarnings(
     "ignore",
@@ -918,13 +917,14 @@ class Mix(AbstractComponent):
             return consumed_volumes, made_volumes
 
         made_volumes[self.name] = self.total_volume
+        consumed_volumes[self.name] = ZERO_VOL
 
         for action in self.actions:
             for component, volume in zip(
                 action.components, action.each_volumes(self.total_volume, self.actions)
             ):
                 consumed_volumes[component.name] = (
-                    consumed_volumes.get(component.name, 0 * ureg.ul) + volume
+                    consumed_volumes.get(component.name, ZERO_VOL) + volume
                 )
                 component._update_volumes(consumed_volumes, made_volumes)
 

--- a/src/alhambra_mixes/mixes.py
+++ b/src/alhambra_mixes/mixes.py
@@ -945,6 +945,8 @@ class Mix(AbstractComponent):
         for a in cast("Sequence[Attribute]", self.__attrs_attrs__):
             if a.name == "actions":
                 d[a.name] = [a._unstructure(experiment) for a in self.actions]
+            elif a.name == "reference":
+                continue
             else:
                 val = getattr(self, a.name)
                 if val == a.default:

--- a/src/alhambra_mixes/mixes.py
+++ b/src/alhambra_mixes/mixes.py
@@ -151,7 +151,7 @@ class Mix(AbstractComponent):
     actions: Sequence[AbstractAction] = attrs.field(
         converter=_maybesequence_action, on_setattr=attrs.setters.convert
     )
-    name: str
+    name: str = ""
     test_tube_name: str | None = attrs.field(kw_only=True, default=None)
     "A short name, eg, for labelling a test tube."
     fixed_total_volume: Quantity[Decimal] = attrs.field(

--- a/src/alhambra_mixes/quantitate.py
+++ b/src/alhambra_mixes/quantitate.py
@@ -429,8 +429,8 @@ def display_measure_conc_and_dilute_from_specs(
         If do not want to convert the specs file to UTF-8 and you are certain that no important Unicode
         characters would be dropped, then you can set this parameter to false.
     """
+    from IPython.display import Markdown, display
     from tabulate import tabulate
-    from IPython.display import display, Markdown
 
     names_to_concs_and_vols_to_add = measure_conc_and_dilute_from_specs(
         filename=filename,
@@ -782,10 +782,10 @@ def _read_dataframe_from_excel_or_csv(
         if enforce_utf8 and not _is_utf8(filename):
             raise ValueError(
                 f"""{filename}
-is not a valid UTF-8 file. To avoid accidentally skipping Unicode 
-characters such as µ (which would silently convert µL to L, for instance), 
-first convert the file to UTF-8 format. Alternately, if you are certain that 
-the file contains no important Unicode characters, set the parameter 
+is not a valid UTF-8 file. To avoid accidentally skipping Unicode
+characters such as µ (which would silently convert µL to L, for instance),
+first convert the file to UTF-8 format. Alternately, if you are certain that
+the file contains no important Unicode characters, set the parameter
 enforce_utf8 to False to avoid getting this error."""
             )
         # encoding_errors='ignore' prevents problems with, e.g., µ Unicode symbol

--- a/src/alhambra_mixes/references.py
+++ b/src/alhambra_mixes/references.py
@@ -8,10 +8,9 @@ from typing import TYPE_CHECKING, Any, Mapping, Sequence, TextIO, cast
 import attrs
 from typing_extensions import TypeAlias
 
-from .mixes import PlateMap
-
+from .components import Component, Strand
 from .locations import PlateType, WellPos, _parse_wellpos_optional
-from .components import Strand, Component
+from .mixes import PlateMap
 from .units import (
     DNAN,
     Q_,

--- a/src/alhambra_mixes/units.py
+++ b/src/alhambra_mixes/units.py
@@ -139,6 +139,27 @@ def _parse_vol_optional(v: str | pint.Quantity) -> pint.Quantity:
     raise ValueError
 
 
+def _parse_vol_optional_none_zero(v: str | pint.Quantity) -> pint.Quantity:
+    """Parses a string or quantity as a volume, returning a NaN volume
+    if the value is None.
+    """
+    # if isinstance(v, (float, int)):  # FIXME: was in quantitate.py, but potentially unsafe
+    #    v = f"{v} µL"
+    if isinstance(v, str):
+        q = ureg(v)
+        if not q.check(uL):
+            raise ValueError(f"{v} is not a valid quantity here (should be volume).")
+        return q
+    elif isinstance(v, pint.Quantity):
+        if not v.check(uL):
+            raise ValueError(f"{v} is not a valid quantity here (should be volume).")
+        v = Q_(v.m, v.u)
+        return v.to_compact()
+    elif v is None:
+        return ZERO_VOL
+    raise ValueError
+
+
 def _parse_vol_required(v: str | pint.Quantity) -> pint.Quantity:
     """Parses a string or quantity as a volume, requiring that it result in a
     value.

--- a/src/alhambra_mixes/util.py
+++ b/src/alhambra_mixes/util.py
@@ -13,3 +13,25 @@ def _maybesequence(object_or_sequence: Sequence[T] | T) -> list[T]:
 
 def _none_as_empty_string(v: str | None) -> str:
     return "" if v is None else v
+
+
+def _unstructure(x):
+    if isinstance(x, ureg.Quantity):
+        return str(x)
+    elif isinstance(x, list):
+        return [_unstructure(y) for y in x]
+    elif isinstance(x, WellPos):
+        return str(x)
+    elif hasattr(x, "__attrs_attrs__"):
+        d = {}
+        d["class"] = x.__class__.__name__
+        for att in x.__attrs_attrs__:
+            if att.name in ["reference"]:
+                continue
+            val = getattr(x, att.name)
+            if val is att.default:
+                continue
+            d[att.name] = _unstructure(val)
+        return d
+    else:
+        return x

--- a/src/alhambra_mixes/util.py
+++ b/src/alhambra_mixes/util.py
@@ -4,34 +4,12 @@ from typing import Sequence, TypeVar
 
 T = TypeVar("T")
 
-
-def _maybesequence(object_or_sequence: Sequence[T] | T) -> list[T]:
-    if isinstance(object_or_sequence, Sequence):
-        return list(object_or_sequence)
-    return [object_or_sequence]
+# Largely replaced by concrete type code.
+# def _maybesequence(object_or_sequence: Sequence[T] | T) -> list[T]:
+#     if isinstance(object_or_sequence, Sequence):
+#         return list(object_or_sequence)
+#     return [object_or_sequence]
 
 
 def _none_as_empty_string(v: str | None) -> str:
     return "" if v is None else v
-
-
-def _unstructure(x):
-    if isinstance(x, ureg.Quantity):
-        return str(x)
-    elif isinstance(x, list):
-        return [_unstructure(y) for y in x]
-    elif isinstance(x, WellPos):
-        return str(x)
-    elif hasattr(x, "__attrs_attrs__"):
-        d = {}
-        d["class"] = x.__class__.__name__
-        for att in x.__attrs_attrs__:
-            if att.name in ["reference"]:
-                continue
-            val = getattr(x, att.name)
-            if val is att.default:
-                continue
-            d[att.name] = _unstructure(val)
-        return d
-    else:
-        return x

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,0 +1,147 @@
+from decimal import Decimal
+import math
+from alhambra_mixes import *
+from alhambra_mixes.abbreviated import *
+import pytest
+import re
+
+
+@pytest.fixture
+def experiment():
+    exp = Exp()
+
+    # We'll make some components:
+    c1 = C("c1", "10 µM", plate="plate1", well="A1")
+    c2 = C("c2", "10 µM", plate="plate1", well="A2")
+    c3 = C("c3", "5 µM", plate="plate1", well="A3")
+    c4 = C("c4", "5 µM", plate="plate2", well="B3")
+
+    # Add a mix with add_mix
+    exp.add_mix(FV([c2, c3], "10 µL"), "mix1")
+
+    # Add a mix by assignment
+    exp["mix2"] = Mix(FC([c1, c4], "1 µM"), fixed_total_volume="10 µL")
+
+    # Add a mix that has a NaN value
+    exp.add_mix(Mix(FC([c1], "1 µM"), "mix3"))
+
+    # Add a mix with mixes, by reference
+    exp["mixmix"] = Mix(FC(["mix1", "mix2", c3], "100 nM"), fixed_total_volume="200 µL")
+
+    return exp
+
+
+def test_forward_reference():
+    exp = Exp()
+
+    exp.add_mix(Mix(FV(["mix1", "mix2"], "10 µL"), "mix3"))
+    exp["mix1"] = Mix(FC(["c1", "c2"], "1 µM"), fixed_total_volume="10 µL")
+    exp["mix2"] = Mix(FC(["c1", "c2"], "1 µM"), fixed_total_volume="10 µL")
+    exp["c1"] = C("c1", "10 µM", plate="plate1", well="A1")
+
+    exp.resolve_components()
+
+    assert exp["mix3"].actions[0].components == [exp["mix1"], exp["mix2"]]
+
+
+def test_iterate_mixes(experiment):
+    assert len(experiment) == 4
+    assert list(experiment) == [
+        experiment["mix1"],
+        experiment["mix2"],
+        experiment["mix3"],
+        experiment["mixmix"],
+    ]
+
+
+def test_consumed_and_produced_volumes(experiment):
+    cp = experiment.consumed_and_produced_volumes()
+
+    # c1 and mix3 can't be directly compared because they have NaN values
+    assert math.isnan(cp["c1"][0].m)
+    assert math.isnan(cp["mix3"][1].m)
+
+    del cp["c1"]
+    del cp["mix3"]
+
+    assert cp == {
+        "mix1": (ureg("4.00000 µL"), ureg("20 µL")),
+        "mix2": (ureg("20 µL"), ureg("10 µL")),
+        "mixmix": (ureg("0 µL"), 200 * ureg("µL")),
+        "c2": (Decimal("10") * ureg("µL"), ureg("0.0 µL")),
+        "c3": (Decimal("14") * ureg("µL"), ureg("0.0 µL")),
+        "c4": (Decimal("2.0") * ureg("µL"), ureg("0.0 µL")),
+        "Buffer": (ureg("179 µL"), ureg("0 µL")),
+    }
+
+
+def test_check_volumes(experiment, capsys):
+    experiment.check_volumes(showall=True)
+    cvstring = capsys.readouterr().out
+    assert re.search(
+        r"Making 10 µl of mix2 but need at least 20(\.0*)? µl", cvstring, re.UNICODE
+    )
+    assert len([x for x in cvstring.splitlines() if x]) == 9
+
+
+def test_unnamed_mix(experiment):
+    with pytest.raises(ValueError):
+        experiment.add_mix(Mix(FC(["a"], "1 µM"), fixed_total_volume="10 µL"))
+    with pytest.raises(ValueError):
+        experiment.add_mix(FC(["a"], "1 µM"), fixed_total_volume="10 µL")
+
+
+def test_add_mix_already_present(experiment):
+    with pytest.raises(ValueError):
+        experiment.add_mix(
+            Mix(
+                FC(["mix1", "mix2", "c3"], "100 nM"),
+                "mixmix",
+                fixed_total_volume="10 µL",
+            )
+        )
+    # with pytest.raises(ValueError):
+    #    experiment['mixmix'] = Mix(FC(["mix1", "mix2", "c3"], "100 nM"), "mixmix", fixed_total_volume="10 µL" )
+
+
+def test_add_wrong_name(experiment):
+    with pytest.raises(ValueError):
+        experiment["mixA"] = Mix(
+            [FC("mix1", "100 nM")], "mixB", fixed_total_volume="10 µL"
+        )
+
+
+def test_save_load(experiment, tmp_path):
+    experiment.save(tmp_path / "test.json")
+
+    e2 = Exp.load(tmp_path / "test.json")
+
+    assert e2 == experiment
+
+
+def test_save_load_on_stream(experiment, tmp_path):
+    with open(tmp_path / "test.json", "w") as f:
+        experiment.save(f)
+
+    with open(tmp_path / "test.json", "r") as f:
+        e2 = Exp.load(f)
+
+    assert e2 == experiment
+
+
+def test_save_load_no_suffix(experiment, tmp_path):
+    experiment.save(tmp_path / "test")
+
+    assert (tmp_path / "test.json").exists()
+
+    e2 = Exp.load(tmp_path / "test")
+
+    assert e2 == experiment
+
+
+def test_load_invalid_json(experiment, tmp_path):
+    with open(tmp_path / "test.json", "w") as f:
+        f.write("{}")
+
+    with pytest.raises(ValueError):
+        Exp.load(tmp_path / "test.json")

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,5 +1,6 @@
-import pytest
 import pandas as pd
+import pytest
+
 from alhambra_mixes import Reference
 
 


### PR DESCRIPTION
This pull request has an Experiment class, which takes a series of mixes, and tracks volumes produced and consumed.

There are some questions that need to be resolved:

- This currently has tracks mixes and components by name.  This may be reasonably safe for mixes, but is not safe for components (may be reordered, etc).  It would be better have some better reference method, though this may not be immediately necessary.
- The Experiment class uses a list of mixes / components.  It may be better to have it use, eg, an ordereddict, keeping track of names.  This would also make the Experiment a convenient way to store/refer to mixes.

Partially closes #4, closes #14, partially closes #13.