### PR TITLE
closes #22: added `split_mix` function for splitting a single large mix into several smaller mixes

### DIFF
--- a/src/alhambra_mixes/__init__.py
+++ b/src/alhambra_mixes/__init__.py
@@ -35,4 +35,5 @@ __all__ = (
     #    "D",
     "measure_conc_and_dilute",
     "hydrate_and_measure_conc_and_dilute",
+    "split_mix",
 )

--- a/src/alhambra_mixes/actions.py
+++ b/src/alhambra_mixes/actions.py
@@ -766,8 +766,10 @@ class FixedConcentration(ActionWithComponents):
 class ToConcentration(ActionWithComponents):
     """Add an amount of (non-mix) components to result in a fixed total concentration of each in the mix.
 
-    An action adding an amount of components such that the concentration of each component in the mix
-    will be at some tapiprget concentration.  Unlike FixedConcentration, which *adds* a certain concentration, this takes into account other contents of the mix, and only adds enough to reach a particular final concentration."""
+    An action adding an amount of components such that the concentration of each component in the mix will
+    be at some target concentration.  Unlike FixedConcentration, which *adds* a certain concentration, this
+    takes into account other contents of the mix, and only adds enough to reach a particular final
+    concentration."""
 
     fixed_concentration: Quantity[Decimal] = attrs.field(
         converter=_parse_conc_required, on_setattr=attrs.setters.convert

--- a/src/alhambra_mixes/actions.py
+++ b/src/alhambra_mixes/actions.py
@@ -37,6 +37,7 @@ class AbstractAction(ABC):
     Abstract class defining an action in a mix recipe.
     """
 
+    @abstractmethod
     @property
     def name(self) -> str:  # pragma: no cover
         ...
@@ -132,6 +133,7 @@ class AbstractAction(ABC):
     ) -> "AbstractAction":  # pragma: no cover
         ...
 
+    @abstractmethod
     def _unstructure(
         self, experiment: "Experiment" | None
     ) -> dict[str, Any]:  # pragma: no cover

--- a/src/alhambra_mixes/actions.py
+++ b/src/alhambra_mixes/actions.py
@@ -37,8 +37,8 @@ class AbstractAction(ABC):
     Abstract class defining an action in a mix recipe.
     """
 
-    @abstractmethod
     @property
+    @abstractmethod
     def name(self) -> str:  # pragma: no cover
         ...
 

--- a/src/alhambra_mixes/mixes.py
+++ b/src/alhambra_mixes/mixes.py
@@ -4,41 +4,24 @@ A module for handling mixes.
 
 from __future__ import annotations
 
-import decimal
-import enum
-import json
-import logging
 import warnings
-from abc import ABC, abstractmethod
-from decimal import Decimal
 from math import isnan
-from os import PathLike
-from pathlib import Path
 from typing import (
-    IO,
     TYPE_CHECKING,
     Any,
     Callable,
     Dict,
-    Iterable,
     Literal,
-    Mapping,
     Sequence,
-    TextIO,
     Tuple,
     TypeVar,
-    Union,
     cast,
-    overload,
 )
 
 import attrs
-import numpy as np
 import pandas as pd
 import pint
-from pint import Quantity
 from tabulate import TableFormat, tabulate
-from typing_extensions import TypeAlias
 
 from .actions import AbstractAction  # Fixme: should not need special cases
 from .actions import FixedConcentration, FixedVolume
@@ -131,7 +114,7 @@ def findloc_tuples(
     except Exception:
         well = loc["Well"]
 
-    return (loc["Name"], loc["Plate"], well)
+    return loc["Name"], loc["Plate"], well
 
 
 def _maybesequence_action(
@@ -1149,12 +1132,17 @@ def split_mix(
     The :meth:`Mix.instructions` method of a split mix includes the additional instruction at the end
     to aliquot from the larger mix.
 
-    :param mix:
+    Parameters
+    ----------
+
+    mix
         The :any:`Mix` object describing what each
         individual smaller test tube should contain after the split.
-    :param num_tubes:
+
+    num_tubes
         The number of test tubes into which to split the large mix.
-    :param excess:
+
+    excess
         A fraction (between 0 and 1) indicating how much extra of the large mix to make. This is useful
         when `num_tubes` is large, since the aliquots prior to the last test tube may take a small amount
         of extra volume, resulting in the final test tube receiving significantly less volume if the
@@ -1170,6 +1158,11 @@ def split_mix(
 
         Note: using `excess` > 0 means than the test tube with the large mix should *not* be
         reused as one of the final test tubes, since it will have too much volume at the end.
+
+    Returns
+    -------
+        A "large" mix, from which `num_tubes` aliquots can be made to create each of the identical
+        "small" mixes.
     """
     if isinstance(excess, (float, int)):
         excess = Decimal(excess)

--- a/src/alhambra_mixes/mixes.py
+++ b/src/alhambra_mixes/mixes.py
@@ -1215,20 +1215,9 @@ def split_mix(
             )
             return super_instructions
 
-    large_mix = SplitMix(
-        actions=actions,
-        name=mix.name,
-        test_tube_name=mix.test_tube_name,
-        fixed_total_volume=large_volume if mix.fixed_total_volume is not None else None,
-        fixed_concentration=mix.fixed_concentration,
-        buffer_name=mix.buffer_name,
-        reference=mix.reference,
-        min_volume=mix.min_volume,
-    )
-
     # replace FixedVolume actions in `large_mix` with larger volumes
     new_fixed_volume_actions = {}
-    for i, action in enumerate(large_mix.actions):
+    for i, action in enumerate(actions):
         if isinstance(action, FixedVolume):
             large_fixed_volume_action = FixedVolume(
                 components=action.components,
@@ -1239,7 +1228,18 @@ def split_mix(
             new_fixed_volume_actions[i] = large_fixed_volume_action
 
     for i, large_fixed_volume_action in new_fixed_volume_actions.items():
-        large_mix.actions[i] = large_fixed_volume_action
+        actions[i] = large_fixed_volume_action
+
+    large_mix = SplitMix(
+        actions=actions,
+        name=mix.name,
+        test_tube_name=mix.test_tube_name,
+        fixed_total_volume=large_volume if mix.fixed_total_volume is not None else None,
+        fixed_concentration=mix.fixed_concentration,
+        buffer_name=mix.buffer_name,
+        reference=mix.reference,
+        min_volume=mix.min_volume,
+    )
 
     return large_mix
 

--- a/src/alhambra_mixes/mixes.py
+++ b/src/alhambra_mixes/mixes.py
@@ -1121,7 +1121,9 @@ class PlateMap:
 
 
 def split_mix(
-    mix: Mix, num_tubes: int, excess: int | float | Decimal = Decimal(0.05)
+    mix: Mix,
+    num_tubes: int,
+    excess: int | float | Decimal = Decimal(0.05),
 ) -> Mix:
     """
     A "split mix" is a :any:`Mix` that involves creating a large volume mix and splitting it into several
@@ -1176,7 +1178,7 @@ def split_mix(
     large_volume = mix.total_volume * volume_multiplier
     actions = list(mix.actions)
 
-    # define subclass with overridden instructions methods that prints final instruction for splitting.
+    # define subclass with overridden instructions method that prints final instruction for splitting.
     @attrs.define(eq=False)
     class SplitMix(Mix):
         def instructions(


### PR DESCRIPTION
Closes #22

Sorry, the name of this branch is misleading. I decided only to implement mix splitting in this branch, and will handle the master mix issue separately.