### PR TITLE
Use minimum buffer volume across mixes for calculation of master mix buffer.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,14 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
     -   id: black
         language_version: python3.10

--- a/src/alhambra_mixes/actions.py
+++ b/src/alhambra_mixes/actions.py
@@ -558,7 +558,6 @@ class EqualConcentration(FixedVolume):
         | tuple[Literal["max_fill"], str] = "min_volume",
         equal_conc: bool | str | None = None,
     ):
-
         if equal_conc is not None:
             warn(
                 "The equal_conc parameter for FixedVolume is no longer supported.  Use EqualConcentration and method instead.",

--- a/src/alhambra_mixes/experiments.py
+++ b/src/alhambra_mixes/experiments.py
@@ -66,7 +66,6 @@ class Experiment:
         apply_reference: bool = True,
         check_existing: bool | Literal["equal"] = "equal",
     ) -> Experiment:
-
         if check_volumes is None:
             check_volumes = self.volume_checks
 

--- a/src/alhambra_mixes/mixes.py
+++ b/src/alhambra_mixes/mixes.py
@@ -259,7 +259,7 @@ class Mix(AbstractComponent):
             )
 
     @property
-    def buffer_volume(self) -> Quantity[Decimal]:
+    def buffer_volume(self) -> Quantity:
         """
         The volume of buffer to be added to the mix, in addition to the components.
         """
@@ -1614,13 +1614,17 @@ def master_mix(
         )
 
     mixes = list(mixes)
+    # We have already required total volumes be the same.
     first_mix = mixes[0]
     total_small_mix_volume = first_mix.total_volume
     volume_shared_actions = sum(
         shared_action.tx_volume(total_small_mix_volume)
         for shared_action in shared_actions
     )
-    volume_buffer = first_mix.buffer_volume
+
+    # We care about the *minimum* buffer volume; then mixes that have more buffer
+    # can have buffer added individually.
+    volume_buffer = min(x.buffer_volume for x in mixes)
     volume_shared_actions_and_buffer = volume_shared_actions + volume_buffer
     concentration_multiplier = total_small_mix_volume / volume_shared_actions_and_buffer
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -140,7 +140,6 @@ def test_consumed_and_produced_volumes(experiment):
 
 
 def test_check_volumes(experiment, capsys):
-
     # First, try adding a mix that will cause a problem
     with pytest.raises(VolumeError):
         experiment.add_mix(

--- a/tests/test_mixes.py
+++ b/tests/test_mixes.py
@@ -654,6 +654,59 @@ def test_master_mix(master_mix_fixture):
         assert strand_ml.names[0] == strand_name
 
 
+def test_master_mix_different_buffer_volumes():
+    from alhambra_mixes import master_mix
+
+    s1 = Component("s1", concentration="100 nM")
+    s2 = Component("s2", concentration="100 nM")
+    s3 = Component("s3", concentration="100 nM")
+    s4 = Component("s4", concentration="100 nM")
+    s5 = Component("s5", concentration="100 nM")
+    s6 = Strand("s6", concentration="100 nM")
+    s7 = Strand("s7", concentration="100 nM")
+    s8 = Strand("s8", concentration="100 nM")
+
+    mixes = [
+        Mix(
+            actions=[
+                FixedConcentration(components=[s1, s2], fixed_concentration=f"10 nM"),
+                FixedConcentration(components=[s3, s4], fixed_concentration=f"10 nM"),
+                FixedConcentration(components=[s5, s6], fixed_concentration=f"10 nM"),
+            ],
+            name="mix 0",
+            fixed_total_volume=f"100 uL",
+        ),
+        Mix(
+            actions=[
+                FixedConcentration(components=[s1, s2], fixed_concentration=f"10 nM"),
+                FixedConcentration(components=[s3, s4], fixed_concentration=f"10 nM"),
+                FixedConcentration(components=[s5, s6], fixed_concentration=f"10 nM"),
+                FixedConcentration(components=[s8], fixed_concentration=f"10 nM"),
+            ],
+            name="mix 1",
+            fixed_total_volume=f"100 uL",
+        ),
+        Mix(
+            actions=[
+                FixedConcentration(components=[s1, s2], fixed_concentration=f"10 nM"),
+                FixedConcentration(components=[s3, s4], fixed_concentration=f"10 nM"),
+                FixedConcentration(components=[s5, s6], fixed_concentration=f"10 nM"),
+                FixedConcentration(components=[s7], fixed_concentration=f"10 nM"),
+                FixedConcentration(components=[s8], fixed_concentration=f"20 nM"),
+            ],
+            name="mix 1",
+            fixed_total_volume=f"100 uL",
+        ),
+    ]
+    mm, final_mixes = master_mix(mixes=mixes, name="master mix")
+
+    mm.validate(tablefmt="pipe", raise_errors=True)
+
+    for mix in final_mixes:
+        assert mix.total_volume == ureg("100 µL")
+        mix.validate(tablefmt="pipe", raise_errors=True)
+
+
 def test_master_mix_exclude_shared_components(master_mix_fixture):
     from alhambra_mixes import master_mix
 

--- a/tests/test_mixes.py
+++ b/tests/test_mixes.py
@@ -1,7 +1,7 @@
 import itertools
 import re
 from decimal import Decimal
-from typing import cast
+from typing import cast, Optional
 
 import numpy as np
 import pandas as pd
@@ -491,7 +491,7 @@ def assert_close(
     expected: Decimal,
     rtol: Decimal = Decimal(1e-7),
     atol: Decimal = Decimal(0),
-    msg: str = None,
+    msg: Optional[str] = None,
 ) -> None:
     # This helps with comparing Decimal quantities, which cannot be multiplied by floats, which is
     # what happens with the default rtol parameter of pint.testing.assert_allclose.

--- a/tests/test_mixes.py
+++ b/tests/test_mixes.py
@@ -104,7 +104,6 @@ def test_all_wellref_96():
 
 
 def test_component():
-
     assert Component("test1") != Component("test2")
 
     assert Component("test3") == Component("test3")
@@ -187,12 +186,12 @@ def test_with_reference_get_first(
         [("P 2", "D7"), ("P 2", "D5"), ("P 3", "D7"), ("P 4", "D7")],
     )
 
-    assert s == Strand("strand3", Q_(1000, nM), "GGTG", plate="P 2", well="D7")
+    assert s == Strand("strand3", Q_(1000, nM), sequence="GGTG", plate="P 2", well="D7")
 
 
 def test_with_reference_constraints_match_plate(reference: Reference, caplog):
     s = Strand("strand3", plate="P 3").with_reference(reference)
-    assert s == Strand("strand3", Q_(2000, nM), "GGTG", plate="P 3", well="D7")
+    assert s == Strand("strand3", Q_(2000, nM), sequence="GGTG", plate="P 3", well="D7")
 
     c = Component("strand3", plate="P 3").with_reference(reference)
     assert c == Component("strand3", Q_(2000, nM), plate="P 3", well="D7")
@@ -200,7 +199,7 @@ def test_with_reference_constraints_match_plate(reference: Reference, caplog):
 
 def test_with_reference_constraints_match_well(reference: Reference, caplog):
     s = Strand("strand3", well="D5").with_reference(reference)
-    assert s == Strand("strand3", Q_(1000, nM), "GGTG", plate="P 2", well="D5")
+    assert s == Strand("strand3", Q_(1000, nM), sequence="GGTG", plate="P 2", well="D5")
 
     c = Component("strand3", well="D5").with_reference(reference)
     assert c == Component("strand3", Q_(1000, nM), plate="P 2", well="D5")
@@ -208,14 +207,16 @@ def test_with_reference_constraints_match_well(reference: Reference, caplog):
 
 def test_with_reference_constraints_match_seq(reference: Reference, caplog):
     s = Strand("strand3", sequence="GGTGAGG").with_reference(reference)
-    assert s == Strand("strand3", Q_(2000, nM), "GGTG AGG", plate="P 4", well="D7")
+    assert s == Strand(
+        "strand3", Q_(2000, nM), sequence="GGTG AGG", plate="P 4", well="D7"
+    )
 
 
 def test_a_mix(reference: Reference):
     c1 = Component("comp1")
     s1 = Strand("strand1")
     s2 = Strand("strand2")
-    s3 = Strand("strand3", ureg("1000 nM"), "GGTG")
+    s3 = Strand("strand3", ureg("1000 nM"), sequence="GGTG")
 
     m = Mix(
         [
@@ -370,7 +371,6 @@ def test_intermediate_mix_sufficient_volume():
 
 
 def test_toconcentration():
-
     ca = Component("A", "1 µM")
     cb = Component("B", "1 µM")
     cc = Component("C", "1 µM")


### PR DESCRIPTION
Currently, we require that mixes have equal total volumes in order to make master mixes of shared components, but we don't require equal buffer volumes, for example, when one mix has a few more components added than another mix.  In order to handle this, we need to use the minimum, not the first, buffer volume of the mixes.  Then mixes with fewer components / more buffer volume before the transformation will have more buffer add individually.